### PR TITLE
Fixes loading with ActionController::API

### DIFF
--- a/lib/stripe/engine.rb
+++ b/lib/stripe/engine.rb
@@ -55,7 +55,10 @@ environment file directly.
 
     initializer 'stripe.javascript_helper' do
       ActiveSupport.on_load :action_controller do
-        helper Stripe::JavascriptHelper
+        # ActionController::API does not have a helper method
+        if respond_to?(:helper)
+          helper Stripe::JavascriptHelper
+        end
       end
     end
 


### PR DESCRIPTION
This adds a check to see if we can call `helper` when loading the
JavascriptHelper as it's not available on ActionController::API and
causes the app to fail to load.

It was easy enough to add the check but I wasn't able to get a test to show the
issue. I've tested it locally against one of our applications (Dead Man's Snitch)
and was able to show it fixes the issue.

Fixes #40